### PR TITLE
Catavento Responsivo

### DIFF
--- a/90sites/04-catavento/style.css
+++ b/90sites/04-catavento/style.css
@@ -78,7 +78,11 @@ main {
     position: relative;
     display: inline-block;
   }
-  
+ 
+#pic-hover, #gif-hover {
+  max-width: 100%;
+}
+
   #hover {
     background:transparent;
     border:0;


### PR DESCRIPTION
Uma simples (bem simples mesmo) mudança, pra deixar o catavento legal no mobile.

Antes ele estava assim, estrapolando a tela:

![image](https://user-images.githubusercontent.com/25728217/90316342-e6e0c500-def7-11ea-9a25-dc3792ab5686.png)

Com a pequena mudança, de definir um width máximo como 100% (toda a tela), ele não pode estrapolar a tela, ficando assim:

![image](https://user-images.githubusercontent.com/25728217/90316350-f4964a80-def7-11ea-8cc4-c44abad30b69.png)
